### PR TITLE
fix(index): add check for driverName in sinkProxies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ const logErrorToConsole = err => {
 const replicateMany = (sinks, sinkProxies) =>
   setTimeout(() => {
     Object.keys(sinks)
+      .filter(driverName => sinkProxies[driverName])
       .forEach(driverName => {
         sinks[driverName]
           .forEach(sinkProxies[driverName].sink.add)


### PR DESCRIPTION
The for-loop previously used had an if statement which
checked if driverName was also a key of sinkProxies.
Add that check back.