### PR TITLE
chore(): update all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "validate-commit-message": "3.0.1"
   },
   "dependencies": {
-    "@most/hold": "1.0.0",
+    "@most/hold": "1.1.0",
     "most": "0.18.0",
-    "most-subject": "2.0.1"
+    "most-subject": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,27 +50,27 @@
   ],
   "devDependencies": {
     "assert": "1.3.0",
-    "babel-cli": "6.3.13",
-    "babel-core": "6.3.13",
-    "babel-eslint": "5.0.0-beta4",
+    "babel-cli": "6.4.5",
+    "babel-core": "6.4.5",
+    "babel-eslint": "4.1.8",
     "babel-preset-es2015": "6.3.13",
     "babelify": "7.2.0",
-    "browserify": "12.0.1",
-    "browserify-shim": "3.8.11",
+    "browserify": "13.0.0",
+    "browserify-shim": "3.8.12",
     "cli-release": "1.0.4",
-    "eslint": "1.0.0",
-    "eslint-config-cycle": "3.1.0",
+    "eslint": "1.10.3",
+    "eslint-config-cycle": "3.2.0",
     "eslint-plugin-cycle": "1.0.2",
     "eslint-plugin-no-class": "0.1.0",
-    "mocha": "2.3.4",
-    "sinon": "1.17.2",
+    "mocha": "2.4.5",
+    "sinon": "1.17.3",
     "testem": "0.9.11",
     "uglifyjs": "2.4.10",
     "validate-commit-message": "3.0.1"
   },
   "dependencies": {
-    "@most/hold": "0.2.0",
-    "most": "0.16.0",
-    "most-subject": "1.0.1"
+    "@most/hold": "1.0.0",
+    "most": "0.18.0",
+    "most-subject": "2.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
-import subject from 'most-subject'
-import hold from '@most/hold'
+import {subject, holdSubject} from 'most-subject'
 
 const makeSinkProxies = drivers =>
   Object.keys(drivers)
     .reduce((sinkProxies, driverName) => {
-      sinkProxies[driverName] = subject()
+      sinkProxies[driverName] = holdSubject()
       return sinkProxies
     }, {})
 
@@ -12,7 +11,7 @@ const callDrivers = (drivers, sinkProxies) =>
   Object.keys(drivers)
     .reduce((sources, driverName) => {
       sources[driverName] =
-        drivers[driverName](hold(sinkProxies[driverName].stream), driverName)
+        drivers[driverName](sinkProxies[driverName].stream, driverName)
       return sources
     }, {})
 


### PR DESCRIPTION
Update all dependencies to their latest versions except testem.
Testem 1.x.x is painfully slow to start.

References motorcyclejs/motorcycle#20