### PR TITLE
refactor(): add error message of undefined sinks in main

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,20 @@ const callDrivers = (drivers, sinkProxies) =>
       return sources
     }, {})
 
+const assertSinks = sinks => {
+  Object.keys(sinks).forEach(key => {
+    if (!sinks[key]) {
+      throw new Error(`Sink \`${key}\` is not a Stream`)
+    }
+  })
+
+  return sinks
+}
+
 const runMain = (main, sources, disposableStream) => {
   const sinks = main(sources)
+  assertSinks(sinks)
+
   return Object.keys(sinks)
     .reduce((accumulator, driverName) => {
       accumulator[driverName] = sinks[driverName].until(disposableStream)


### PR DESCRIPTION
This PR improves reporting of developer errors. If main returns a sink which is not truthy, an explicit error message is thrown to developer:

<img width="322" alt="screenshot 2016-03-02 16 54 23" src="https://cloud.githubusercontent.com/assets/1232405/13464007/ada896f4-e097-11e5-89d1-17f24a22a5a7.png">


