### PR TITLE
feat(): general updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.1.0 (2016-02-07)
+
+
+## Bug Fixes
+
+- revert breaking change related to drivers
+  ([f110f0a3](https://github.com/motorcyclejs/core/commits/f110f0a3a35e7824c2850f7cd9bc7f31d24b912f),
+   [#35]([object Object]/35))
+
+
 # v1.0.0 (2015-12-30)
 
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ and outputs a collection of sinks Observables/Streams.
 **drivers** :: Object - an object where keys are driver names
 and values are driver functions.
 
+**{onError}** :: Object - an object which currently only accepts an `onError()`
+function. The optional `onError()` function allows for defining a custom Function
+to be called when an error occurs in a stream from your application.
+
 ###### Return:
 
 (Object) an object containing *sources*, *sinks*, and *dispose()* that

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "dependencies": {
     "@most/hold": "1.1.0",
     "most": "0.18.0",
-    "most-subject": "2.1.0"
+    "most-subject": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motorcycle/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Cycle.js with most.js reactive library instead of RxJS.",
   "main": "lib/index.js",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,50 +1,64 @@
 import {subject, holdSubject} from 'most-subject'
 
-const makeSinkProxies = drivers =>
-  Object.keys(drivers)
-    .reduce((sinkProxies, driverName) => {
-      sinkProxies[driverName] = holdSubject()
-      return sinkProxies
-    }, {})
-
-const callDrivers = (drivers, sinkProxies) =>
-  Object.keys(drivers)
-    .reduce((sources, driverName) => {
-      sources[driverName] =
-        drivers[driverName](sinkProxies[driverName].stream, driverName)
-      return sources
-    }, {})
-
-const runMain = (main, sources, disposableStream) => {
-  const sinks = main(sources)
-  return Object.keys(sinks)
-    .reduce((accumulator, driverName) => {
-      accumulator[driverName] = sinks[driverName].until(disposableStream)
-      return accumulator
-    }, {})
+function makeSinkProxies(drivers) {
+  const sinkProxies = {}
+  const keys = Object.keys(drivers)
+  for (let i = 0; i < keys.length; i++) {
+    sinkProxies[keys[i]] = holdSubject(1)
+  }
+  return sinkProxies
 }
 
-const logErrorToConsole = err => {
-  if (console && console.error) {
-    console.error(err.message)
+function callDrivers(drivers, sinkProxies) {
+  const sources = {}
+  const keys = Object.keys(drivers)
+  for (let i = 0; i < keys.length; i++) {
+    let name = keys[i]
+    sources[name] = drivers[name](sinkProxies[name].stream, name)
+  }
+  return sources
+}
+
+function makeHandleError(observer, onError) {
+  return function handleError(err) {
+    observer.error(err)
+    onError(err)
   }
 }
 
-const replicateMany = (sinks, sinkProxies) =>
-  setTimeout(() => {
-    Object.keys(sinks)
-      .filter(driverName => sinkProxies[driverName])
-      .forEach(driverName => {
-        sinks[driverName]
-          .forEach(sinkProxies[driverName].sink.add)
-          .then(sinkProxies[driverName].sink.end)
-          .catch(logErrorToConsole)
-      })
-  }, 1)
+function replicateMany({sinks, sinkProxies, disposableStream, onError}) {
+  const sinkKeys = Object.keys(sinks)
+  for (let i = 0; i < sinkKeys.length; i++) {
+    let name = sinkKeys[i]
+    if (sinkProxies.hasOwnProperty(name)) {
+      let {observer} = sinkProxies[name]
+      sinks[name]
+        .until(disposableStream)
+        .observe(observer.next)
+        .then(observer.complete)
+        .catch(makeHandleError(observer, onError))
+    }
+  }
+}
 
-const isObjectEmpty = object => Object.keys(object).length <= 0
+function assertSinks(sinks) {
+  const keys = Object.keys(sinks)
+  for (let i = 0; i < keys.length; i++) {
+    if (!sinks[keys[i]] || typeof sinks[keys[i]].observe !== `function`) {
+      throw new Error(`Sink '${keys[i]}' must be a most.Stream`)
+    }
+  }
+  return sinks
+}
 
-const run = (main, drivers) => {
+const logErrorToConsole = typeof console !== `undefined` && console.error ?
+  error => { console.error(error.stack || error) } : Function.prototype
+
+const defaults = {
+  onEror: logErrorToConsole,
+}
+
+function runInputGuard({main, drivers, onError}) {
   if (typeof main !== `function`) {
     throw new Error(`First argument given to run() must be the ` +
       `'main' function.`)
@@ -53,20 +67,27 @@ const run = (main, drivers) => {
     throw new Error(`Second argument given to run() must be an ` +
       `object with driver functions as properties.`)
   }
-  if (isObjectEmpty(drivers)) {
+  if (!Object.keys(drivers).length) {
     throw new Error(`Second argument given to run() must be an ` +
       `object with at least one driver function declared as a property.`)
   }
-  const {sink: disposableSink, stream: disposableStream} = subject()
-  const sinkProxies = makeSinkProxies(drivers, disposableStream)
-  const sources = callDrivers(drivers, sinkProxies)
-  const sinks = runMain(main, sources, disposableStream)
-  replicateMany(sinks, sinkProxies)
 
-  const dispose = () => {
-    disposableSink.add(1)
-    Object.keys(sinkProxies).forEach(key => sinkProxies[key].sink.end())
-    disposableSink.end()
+  if (typeof onError !== `function`) {
+    throw new Error(`onError must be a function`)
+  }
+}
+
+function run(main, drivers, {onError = logErrorToConsole} = defaults) {
+  runInputGuard({main, drivers, onError})
+  const {observer: disposableObserver, stream: disposableStream} = subject()
+  const sinkProxies = makeSinkProxies(drivers)
+  const sources = callDrivers(drivers, sinkProxies)
+  const sinks = assertSinks(main(sources))
+  replicateMany({sinks, sinkProxies, disposableStream, onError})
+
+  function dispose() {
+    disposableObserver.next(1)
+    disposableObserver.complete()
   }
 
   return {sinks, sources, dispose}

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ const logErrorToConsole = typeof console !== `undefined` && console.error ?
   error => { console.error(error.stack || error) } : Function.prototype
 
 const defaults = {
-  onEror: logErrorToConsole,
+  onError: logErrorToConsole,
 }
 
 function runInputGuard({main, drivers, onError}) {

--- a/test/index.js
+++ b/test/index.js
@@ -57,6 +57,18 @@ describe(`Motorcycle`, () => {
       done();
     });
 
+    it(`should throw error if sink is not a stream`, () => {
+      const app = () => ({
+        other: {}
+      })
+
+      const dirver = sink => sink.map(x => x * x)
+
+      assert.throws(() => {
+        run(app, {other: driver})
+      }, Error, /Sink other must be a most\.Stream/)
+    })
+
     it('should happen on event loop\'s next tick', done => {
       const app = () => ({
         other: Most.from([10, 20, 30])
@@ -71,8 +83,7 @@ describe(`Motorcycle`, () => {
       sources.other.take(1).observe(x => {
         assert.strictEqual(x, 'a10')
         assert.strictEqual(mutable, 'correct')
-        done()
-      })
+      }).then(() => done()).catch(done.fail)
       mutable = 'correct'
     })
 
@@ -174,11 +185,6 @@ describe(`Motorcycle`, () => {
 
       setTimeout(() => {
         sinon.assert.calledOnce(console.error);
-        const errorMessage =
-        sinon.assert.calledWithExactly(
-          console.error,
-          sinon.match('malfunction')
-        )
         sandbox.restore();
         done();
       }, 10);


### PR DESCRIPTION
Add the option to use your own onError function.
Assert that sinks are being returned as streams
Refactor to use function declarations instead of arrow function expressions
Use for-loops for performance gain.

Included the work from #48

Closes #47